### PR TITLE
Add back a missing reference

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -164,3 +164,9 @@
   note={US Patent 7,418,369}
 }
 
+@phdthesis{gruntz1996computing,
+  title={On computing limits in a symbolic manipulation system},
+  author={Gruntz, Dominik},
+  year={1996},
+  school={Swiss Federal Institute of Technology}
+}


### PR DESCRIPTION
This reference was removed in 1ea403206d9a18f76d83068e8c6f517ffea8a41f, so this commit just adds it back in.
