### PR TITLE
Add authors.json and related files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 all:
+	cd authors; ./list_latex.py
 	pdflatex -shell-escape paper.tex
 	bibtex paper.aux
 	pdflatex -shell-escape paper.tex

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all:
 	pdflatex -shell-escape paper.tex
 	pdflatex -shell-escape paper.tex
 travis:
+	cd authors; ./list_latex.py
 	pdflatex -shell-escape --halt-on-error paper.tex
 	bibtex paper.aux
 	pdflatex -shell-escape --halt-on-error paper.tex

--- a/authors/README.md
+++ b/authors/README.md
@@ -1,0 +1,17 @@
+# Authors List
+
+## Usage
+
+* Call `./prettify.sh` after modyfing `authors.json`.
+* Use `./list_text.sh` to list the authors as text
+* Use `./list_latex.sh` to list the authors as latex source code
+
+## How to add a new author
+
+Send a PR adding a new author into the json file. This PR must be approved by
+Anthony Scopatz. We follow the criteria stated in the main
+[README file](https://github.com/sympy/sympy-paper/blob/master/README.md#authorship-criteria).
+Anthony will make sure that the new author meets all the criteria. For
+clear-cut cases (when nobody has any doubts that the criteria have been met),
+Anthony will simply merge the PR. For borderline cases, Anthony will consult
+the community.

--- a/authors/authors.json
+++ b/authors/authors.json
@@ -1,0 +1,16 @@
+[
+    {
+        "email": "ondrej.certik@gmail.com",
+        "github_id": "certik",
+        "institution": "Los Alamos National Laboratory",
+        "institution_address": "P.O. Box 1663, Los Alamos, New Mexico 87545, USA",
+        "name": "Ond\u0159ej \u010cert\u00edk"
+    },
+    {
+        "email": "isuru.11@cse.mrt.ac.lk",
+        "github_id": "isuruf",
+        "institution": "University of Moratuwa",
+        "institution_address": "Bandaranayake Mawatha, Katubedda, Moratuwa 10400, Sri Lanka",
+        "name": "Isuru Fernando"
+    }
+]

--- a/authors/list_latex.py
+++ b/authors/list_latex.py
@@ -6,10 +6,8 @@ from json import load
 
 author_list = load(open("authors.json"))
 
-print("List of authors:")
-print()
-
-for author in author_list:
-    print(r"\author{%s}" % author["name"])
-    # TODO: Print more info in Latex format here
-    print()
+with open("../authors.tex", "wb") as f:
+    for author in author_list:
+        f.write(("\\author{%s}\n" % author["name"]).encode("utf-8"))
+        f.write(("\\affil{%s}\n" % author["institution"]).encode("utf-8"))
+        f.write("\n".encode("utf-8"))

--- a/authors/list_latex.py
+++ b/authors/list_latex.py
@@ -1,0 +1,15 @@
+#! /usr/bin/env python
+
+from __future__ import print_function
+
+from json import load
+
+author_list = load(open("authors.json"))
+
+print("List of authors:")
+print()
+
+for author in author_list:
+    print(r"\author{%s}" % author["name"])
+    # TODO: Print more info in Latex format here
+    print()

--- a/authors/list_text.py
+++ b/authors/list_text.py
@@ -1,0 +1,19 @@
+#! /usr/bin/env python
+
+from __future__ import print_function
+
+from json import load
+
+author_list = load(open("authors.json"))
+
+print("List of authors:")
+print()
+
+for author in author_list:
+    print("Author:", author["name"])
+    print("Affiliation:", author["institution"])
+    print("Address:", author["institution_address"])
+    print("GitHub profile: https://github.com/%s" % author["github_id"])
+    print("Article commits: https://github.com/sympy/sympy-paper/commits?author=%s" % author["github_id"])
+    print("Article comments on issues and PRs: https://github.com/sympy/sympy-paper/search?q=%s&type=Issues" % author["github_id"])
+    print()

--- a/authors/prettify.sh
+++ b/authors/prettify.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+set -e
+
+python -m json.tool authors.json > authors.json.tmp
+mv authors.json.tmp authors.json

--- a/paper.tex
+++ b/paper.tex
@@ -1,4 +1,5 @@
 \documentclass{article}
+\usepackage{authblk}
 \usepackage{hyperref}
 \usepackage{graphicx}
 \usepackage{amsmath}
@@ -31,6 +32,8 @@
 \usepackage{amssymb}
 
 \title{SymPy: Symbolic Computing in Python}
+
+\input{authors}
 
 \begin{document}
 \maketitle


### PR DESCRIPTION
The `authors.json` contains all the information about authors of this article. Use the provides scripts to parse this information into the form that we need. E.g. to print information about each author into the terminal, do:

```
$ ./list_text.py 
List of authors:

Author: Ondřej Čertík
Affiliation: Los Alamos National Laboratory
Address: P.O. Box 1663, Los Alamos, New Mexico 87545, USA
GitHub profile: https://github.com/certik
Article commits: https://github.com/sympy/sympy-paper/commits?author=certik
Article comments on issues and PRs: https://github.com/sympy/sympy-paper/search?q=certik&type=Issues

Author: Isuru Fernando
Affiliation: University of Moratuwa
Address: Bandaranayake Mawatha, Katubedda, Moratuwa 10400, Sri Lanka
GitHub profile: https://github.com/isuruf
Article commits: https://github.com/sympy/sympy-paper/commits?author=isuruf
Article comments on issues and PRs: https://github.com/sympy/sympy-paper/search?q=isuruf&type=Issues
```

To get the list of authors in Latex so that we can paste it into the main latex file, do:

```
$ ./list_latex.py 
List of authors:

\author{Ondřej Čertík}

\author{Isuru Fernando}
```

(More information should be exported to Latex, we can improve the script later.)

/cc @asmeurer, @scopatz 
