### PR TITLE
Enable Unicode Support  (Alternative II)

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -1,5 +1,8 @@
 % SIAM Article Template
 \documentclass[review]{siamart0216}
+
+\usepackage[utf8]{inputenc}
+
 \usepackage{hyperref}
 \usepackage{graphicx}
 \usepackage{amsmath}


### PR DESCRIPTION
This is an alternative, perhaps a better, patch to #88, since this shows how to make unicode printing work with pdflatex.
