### PR TITLE
Remove Wikipedia references

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -3317,22 +3317,6 @@ ng {C}omputations in {C}ommutative {A}lgebra},
   url = {https://reference.wolfram.com/language/tutorial/FlatAndOrderlessFunctions.html},
 }
 
-@misc{wiki:fourier,
-   author = "Wikipedia",
-   title = "Fourier series --- Wikipedia{,} The Free Encyclopedia",
-   year = "2016",
-   url = "\url{https://en.wikipedia.org/w/index.php?title=Fourier_series&oldid=709473989}",
-   note = "[Online; accessed 21-April-2016]"
- }
-
-@misc{ wiki:formal,
-   author = "Wikipedia",
-   title = "Formal power series --- Wikipedia{,} The Free Encyclopedia",
-   year = "2016",
-   url = "\url{https://en.wikipedia.org/w/index.php?title=Formal_power_series&oldid=714764056}",
-   note = "[Online; accessed 21-April-2016]"
- }
-
 @book{zimmerman,
    title={Modern Computer Arithmetic},
    author={Richard P. Brent and Paul Zimmermann},

--- a/series.tex
+++ b/series.tex
@@ -22,7 +22,7 @@ The newer and much faster\cite{sympyRingSeries} approach called Ring Series make
 observation that a truncated Taylor series, is in fact a polynomial.
 Ring Series uses the efficient representation and operations of sparse
 polynomials. The choice of sparse polynomials is deliberate as it performs
-well in a wider range of cases than a dense representation. Ring Series gives 
+well in a wider range of cases than a dense representation. Ring Series gives
 the user the freedom to choose the type of coefficients he wants to have in
 his series, allowing the use of faster operations on certain types.
 
@@ -61,7 +61,7 @@ there is no need to explicitly create a polynomial \texttt{ring}. An example:
 
 \subsubsection{Formal Power Series}
 
-SymPy can be used for computing the Formal Power Series\cite{wiki:formal} of a function.
+SymPy can be used for computing the Formal Power Series of a function.
 The implementation is based on the algorithm described in the paper on
 Formal Power Series\cite{Gruntz93formalpower}.  The advantage of this approach is
 that an explicit formula for the coefficients of the series expansion is generated
@@ -79,7 +79,7 @@ x - x**3/6 + x**5/120 + O(x**6)
 
 \subsubsection{Fourier Series}
 
-SymPy provides functionality to compute Fourier Series\cite{wiki:fourier} of a function using
+SymPy provides functionality to compute Fourier Series of a function using
 the \texttt{fourier\_series} function. Under the hood it just computes $a0$, $an$, $bn$ using
 standard integration formulas.
 


### PR DESCRIPTION
They were causing the build to fail, and I don't think we should be
referencing Wikipedia anyway.
