### PR TITLE
Use T1 font encoding and Latin Modern fonts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 before_install:
 - sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended
   texlive-latex-extra texlive-fonts-extra texlive-humanities texlive-science latex-xcolor
-  dvipng texlive-latex-recommended python-pygments
+  dvipng texlive-latex-recommended python-pygments lmodern
 script:
 - make travis
 - sh upload_travis.sh

--- a/paper.tex
+++ b/paper.tex
@@ -1,6 +1,7 @@
 % SIAM Article Template
 \documentclass[review]{siamart0216}
 
+\usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 
 \usepackage{hyperref}

--- a/paper.tex
+++ b/paper.tex
@@ -1,6 +1,7 @@
 % SIAM Article Template
 \documentclass[review]{siamart0216}
 
+\usepackage{lmodern}
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 


### PR DESCRIPTION
This makes sure that unicode characters like Č are present in the font, and
thus displayed properly.

Before this PR:
![old](https://cloud.githubusercontent.com/assets/20568/15195121/ae168006-1783-11e6-9b3c-e34cd9f15fb0.png)
after this PR:
![new](https://cloud.githubusercontent.com/assets/20568/15195128/b361b300-1783-11e6-8cbf-759db895dd04.png)

Notice the position of the `v` accent above `C`. Before it was positioned incorrectly, because Latex doesn't have the Č character in the font, and so it simply puts the accent in the middle of the letter, since that's the best it can do --- and so the result looks extremely crappy (perhaps not if you are not used to seeing such letters, but it is obvious to me from first look that the accent is positioned incorrectly). However, the proper way is to have all accented letters in the font itself, since the positioning of accents is specific to each letter.

However, this PR introduces another, unrelated, problem (also apparent from the screenshots above) --- before the font seems to be fully vectorized and looks good if I enlarge the pdf, while in this PR, the font seems rasterized, and so it looks crappy when enlarged. Currently I don't know what is causing it, nor how to fix it.
