### PR TITLE
Fix a bug in the SIAM Article Template

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -1,6 +1,10 @@
 % SIAM Article Template
 \documentclass[review]{siamart0216}
 
+% Apply a fix to the SIAM Article Template
+\input{siamart0216_uppercase_fix}
+
+
 \usepackage[utf8]{inputenc}
 
 \usepackage{hyperref}

--- a/siamart0216_uppercase_fix.tex
+++ b/siamart0216_uppercase_fix.tex
@@ -1,0 +1,7 @@
+% The SIAM's stylesheet uses \uppercase instead of \MakeUppercase, so unicode
+% characters are not converted to uppercase. The fix here was suggested at:
+% http://tex.stackexchange.com/questions/289465/stylesheet-does-not-capitalize-polish-letters-correctly
+
+\makeatletter
+\def\@ucnt#1\thanks{\MakeUppercase{#1}\futurelet\@tempa\@ucnta}
+\makeatother


### PR DESCRIPTION
The problem is that the SIAM Article Template is using \uppercase instead of
\MakeUppercase, as discovered by:

http://tex.stackexchange.com/questions/289465/stylesheet-does-not-capitalize-polish-letters-correctly

We fix it by modifying one of the commands from the template. We will have to
bring this up with the journal while submitting.

Fixes #96.
