### PR TITLE
Use Latin Modern fonts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 before_install:
 - sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended
   texlive-latex-extra texlive-fonts-extra texlive-humanities texlive-science latex-xcolor
-  dvipng texlive-latex-recommended python-pygments
+  dvipng texlive-latex-recommended python-pygments lmodern
 script:
 - make travis
 - sh upload_travis.sh

--- a/paper.tex
+++ b/paper.tex
@@ -1,6 +1,7 @@
 % SIAM Article Template
 \documentclass[review]{siamart0216}
 
+\usepackage{lmodern}
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 


### PR DESCRIPTION
This resolves the bitmap fonts issue introduced in
6e5dda49a9bf0c2ebacaa9f3e0d45e4982bd9d35. The problem is that the standard
Computer Modern fonts are in OT1 encoding, and so when the 6e5dda4 commit
requested T1 font, the bitmap fonts were used, which look ugly in high
resolution.

One solution, implemented in this commit, is to use the Latin Modern fonts,
e.g. in Ubuntu:

```
apt-get install lmodern
```

Which support T1. More information at:

http://tex.stackexchange.com/questions/1291/why-are-bitmap-fonts-used-automatically

The other solution is to use `cm-super`, but as explained at:

http://tex.stackexchange.com/questions/1390/latin-modern-vs-cm-super

it seems that Latin Modern is the way to go to obtain high quality fonts.
