### PR TITLE
Unicode pprint using xetex pdf figure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,10 @@
 ## Intermediate documents:
 *.dvi
 *-converted-to.*
-paper.pdf
 # these rules might exclude image files for figures etc.
 # *.ps
 # *.eps
-# *.pdf
+*.pdf
 
 ## Bibliography auxiliary files (bibtex/biblatex/biber):
 *.bbl

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,10 @@ before_install:
   texlive-latex-extra texlive-fonts-extra texlive-humanities texlive-science latex-xcolor
   dvipng texlive-latex-recommended python-pygments lmodern
 script:
-- make travis
+- make
 - sh upload_travis.sh
 notifications:
   email: false
 env:
   global:
     secure: "V61rKiNGYdR8n1KYQBV7/7zhdk5lCKyiTc0KfB2NqDni8wRIWQ4EkIkKLU+cxOC1XLNxa0zc7WgIhkFaP5aYEKiE66McpsCOPDuoWxt9OJEheoBuJ3iuooAxpoEdYtzKBNSd6Tn2NRm1gW1h13pHfB0ShdDoZyXo2n8REIY3ErRN3uRgu5ce4UM04DcmE3tH7ydlFPLUUSL6m1Bl7q2UscVDmwxBzfORMw1m6WQ6U+ItXbX1pXQ8ucOqM8OdO6HjhF5F3cKqchx+nere3X8weCREKLm4O6UZ+KDCBkbFBJpAzwrB6q1TQaFjcSano69RXPxziNimeb3or4sw5pIVP+W+0sgaUg0fvTNGZIOmxAkv+oEs2X1DYBeArFKrc746Z2rTNY/QkGFjku2TK0dMZSLWNKejEGBierWlJj+sDq/wQeuizOIFjPdxD9FuE7vgIcp5WWmom9YAhhpiH4/+NF0ZXqAwg4Lp7kUysmsKpTa89l/3/D1TV4L75I03OKLt3Zv1g2G8x40XjxpHh4W/MxIWdUGMFTm5CA9ssjhR7BvEV3NfnsBMOwIe/8984vS1JCTuFKW+2sC1COJYn+12uPeQ7l0tjoHW3x1e+9C+IaBvo+2ojVL6Qj+BAk2RN5xWrmQiX8Y9rhVFtlw3xekk5goZrHdYEXZ7hsTQ4NM5sxA="
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 before_install:
 - sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended
   texlive-latex-extra texlive-fonts-extra texlive-humanities texlive-science latex-xcolor
-  dvipng texlive-latex-recommended python-pygments lmodern
+  dvipng texlive-latex-recommended python-pygments lmodern texlive-xetex
 script:
 - make
 - sh upload_travis.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
         texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra \
         texlive-humanities texlive-science latex-xcolor dvipng \
         texlive-latex-recommended python-pygments \
+        lmodern texlive-xetex \
         make \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: authors pprint tex
+all: authors.tex pprint tex
 
 tex:
 	pdflatex -shell-escape --halt-on-error paper.tex
@@ -6,7 +6,7 @@ tex:
 	pdflatex -shell-escape --halt-on-error paper.tex
 	pdflatex -shell-escape --halt-on-error paper.tex
 
-authors:
+authors.tex:
 	cd authors; ./list_latex.py
 
 pprint:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
-all:
-	cd authors; ./list_latex.py
-	pdflatex -shell-escape paper.tex
-	bibtex paper.aux
-	pdflatex -shell-escape paper.tex
-	pdflatex -shell-escape paper.tex
-travis:
-	cd authors; ./list_latex.py
+all: authors pprint tex
+
+tex:
 	pdflatex -shell-escape --halt-on-error paper.tex
 	bibtex paper.aux
 	pdflatex -shell-escape --halt-on-error paper.tex
 	pdflatex -shell-escape --halt-on-error paper.tex
+
+authors:
+	cd authors; ./list_latex.py
+
+pprint:
+	xelatex --halt-on-error pprint.tex
+
 clean:
 	(rm -rf *.ps *.log *.dvi *.aux *.*% *.lof *.lop *.lot *.toc *.idx *.ilg *.ind *.bbl *.blg *.cpt)

--- a/paper.tex
+++ b/paper.tex
@@ -7,7 +7,7 @@
 \usepackage{lmodern}
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
-\usepackage{DejaVuSansMono}
+\usepackage[scaled=0.8]{DejaVuSansMono}
 
 \usepackage{hyperref}
 \usepackage{graphicx}

--- a/paper.tex
+++ b/paper.tex
@@ -7,6 +7,7 @@
 \usepackage{lmodern}
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
+\usepackage{DejaVuSansMono}
 
 \usepackage{hyperref}
 \usepackage{graphicx}

--- a/pprint.tex
+++ b/pprint.tex
@@ -5,10 +5,9 @@
 \usepackage{xunicode}
 \usepackage{verbatim}
 \usepackage{fontspec}
-\usepackage[margin=0in, paperwidth=5.125in, paperheight=0.858in]{geometry}
-% 6.2 in width for 80 characters
-% 1.03 in = 6 lines
-% Add an extra line at the bottom for spacing
+\usepackage[margin=0in, paperwidth=5.125in, paperheight=0.7in]{geometry}
+% The width comes from the SIAM style file
+% The height is the smallest height that doesn't crop the text
 
 \setmonofont[Scale=0.8]{DejaVu Sans Mono}
 \tracingonline=1 % Show missing characters in the command line

--- a/pprint.tex
+++ b/pprint.tex
@@ -10,8 +10,9 @@
 % 1.03 in = 6 lines
 % Add an extra line at the bottom for spacing
 
-\setmonofont{DejaVu Sans Mono}
+\setmonofont[Scale=0.8]{DejaVu Sans Mono}
 \tracingonline=1 % Show missing characters in the command line
+
 \begin{document}
 \begin{verbatim}
 >>> pprint(Integral(sqrt(phi0 + 1), phi0))

--- a/pprint.tex
+++ b/pprint.tex
@@ -13,6 +13,9 @@
 \setmonofont[Scale=0.8]{DejaVu Sans Mono}
 \tracingonline=1 % Show missing characters in the command line
 
+\setlength\lineskiplimit{-1000pt}
+\linespread{0.79}
+
 \begin{document}
 \begin{verbatim}
 >>> pprint(Integral(sqrt(phi0 + 1), phi0))

--- a/pprint.tex
+++ b/pprint.tex
@@ -1,0 +1,23 @@
+\documentclass{article}
+\usepackage{fancyvrb}
+\usepackage[usenames]{color}
+\usepackage{xltxtra}
+\usepackage{xunicode}
+\usepackage{verbatim}
+\usepackage{fontspec}
+\usepackage[margin=0in, paperwidth=6.2in, paperheight=1.37in]{geometry}
+% 6.2 in width for 80 characters
+% 1.03 in = 6 lines
+% Add an extra line at the bottom for spacing
+
+\setmonofont{DejaVu Sans Mono}
+\tracingonline=1 % Show missing characters in the command line
+\begin{document}
+\begin{verbatim}
+>>> pprint(Integral(sqrt(phi0 + 1), phi0))
+⌠
+⎮   ________
+⎮ ╲╱ φ₀ + 1  d(φ₀)
+⌡
+\end{verbatim}
+\end{document}

--- a/pprint.tex
+++ b/pprint.tex
@@ -5,7 +5,7 @@
 \usepackage{xunicode}
 \usepackage{verbatim}
 \usepackage{fontspec}
-\usepackage[margin=0in, paperwidth=6.2in, paperheight=1.37in]{geometry}
+\usepackage[margin=0in, paperwidth=6.2in, paperheight=1.03in]{geometry}
 % 6.2 in width for 80 characters
 % 1.03 in = 6 lines
 % Add an extra line at the bottom for spacing

--- a/pprint.tex
+++ b/pprint.tex
@@ -5,7 +5,7 @@
 \usepackage{xunicode}
 \usepackage{verbatim}
 \usepackage{fontspec}
-\usepackage[margin=0in, paperwidth=5.125in, paperheight=1.03in]{geometry}
+\usepackage[margin=0in, paperwidth=5.125in, paperheight=0.858in]{geometry}
 % 6.2 in width for 80 characters
 % 1.03 in = 6 lines
 % Add an extra line at the bottom for spacing

--- a/pprint.tex
+++ b/pprint.tex
@@ -5,7 +5,7 @@
 \usepackage{xunicode}
 \usepackage{verbatim}
 \usepackage{fontspec}
-\usepackage[margin=0in, paperwidth=6.2in, paperheight=1.03in]{geometry}
+\usepackage[margin=0in, paperwidth=5.125in, paperheight=1.03in]{geometry}
 % 6.2 in width for 80 characters
 % 1.03 in = 6 lines
 % Add an extra line at the bottom for spacing

--- a/printers.tex
+++ b/printers.tex
@@ -15,6 +15,7 @@ uses Unicode characters to render mathematical symbols such as integral signs,
 square roots, and parentheses. Greek letters and subscripts in symbol names
 are rendered automatically.
 
+\noindent
 \includegraphics[width=1\textwidth]{pprint.pdf}
 
 Alternately, the \verb|use_unicode=False| flag can be set, which causes the

--- a/printers.tex
+++ b/printers.tex
@@ -17,7 +17,6 @@ are rendered automatically.
 
 \noindent
 \includegraphics[width=1\textwidth]{pprint.pdf}
-
 Alternately, the \verb|use_unicode=False| flag can be set, which causes the
 expression to be printed using only ASCII characters.
 

--- a/printers.tex
+++ b/printers.tex
@@ -15,6 +15,8 @@ uses Unicode characters to render mathematical symbols such as integral signs,
 square roots, and parentheses. Greek letters and subscripts in symbol names
 are rendered automatically.
 
+\includegraphics[width=1\textwidth]{pprint.pdf}
+
 Alternately, the \verb|use_unicode=False| flag can be set, which causes the
 expression to be printed using only ASCII characters.
 


### PR DESCRIPTION
Working on the Unicode pprint example, using xetex to generate a pdf "figure".

You can see the basic idea of how it works. Some issues:
- [x] The example is indented
- [x] There is an extra line below the text
- [x] The font size doesn't exactly match
- [ ] I am using DejaVu Sans Mono because that has all the characters (hopefully this will build on Travis). But this looks different from all the other examples. We might need to find a more standard LaTeX font that has the characters, or else set the mono font for the whole paper. 
- [x] The spacing between the integral sign characters is not right.
