### PR TITLE
Fix Makefile (update authors correctly)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ tex:
 	pdflatex -shell-escape --halt-on-error paper.tex
 	pdflatex -shell-escape --halt-on-error paper.tex
 
-authors.tex:
+authors.tex: authors/authors.json
 	cd authors; ./list_latex.py
 
 pprint:


### PR DESCRIPTION
Previously `make` would not rebuild the `authors.tex` file if you modified `authors.json`.
