### PR TITLE
Generate a nice authors.md file

### DIFF
--- a/authors/authors.json
+++ b/authors/authors.json
@@ -146,6 +146,7 @@
     {
         "email": "cimrman3@ntc.zcu.cz",
         "github_id": "rc",
+        "sympy_commit_email": "robert.cimrman@gmail.com",
         "institution": "New Technologies - Research Centre, University of West Bohemia",
         "institution_address": "Univerzitní 8, 306 14 Plzeň, Czech Republic",
         "institution_address_siam": "Univerzitní 8, 306 14 Plzeň, Czech Republic",

--- a/authors/list_text.py
+++ b/authors/list_text.py
@@ -49,6 +49,14 @@ Finally, all authors agreed to the requirement 4.
             ":---                  | :---        |\n")
 
     for author in author_list:
+        # Some authors used an alternate email address, not associated with
+        # their GitHub profile, which causes GitHub not to show their commits
+        # if we use the `github_id` field. For these authors we must use the
+        # `sympy_commit_email` field.
+        if "sympy_commit_email" in author:
+            sympy_commit_id = author["sympy_commit_email"]
+        else:
+            sympy_commit_id = author["github_id"]
         f.write(u"| %s | [@%s](https://github.com/%s) | "
             "[%d](https://github.com/sympy/sympy/commits?author=%s) | "
             "[commits](https://github.com/sympy/sympy-paper/commits?author=%s),"
@@ -57,7 +65,7 @@ Finally, all authors agreed to the requirement 4.
             "| %s, %s |\n" % (
                 author["name"],
                 author["github_id"], author["github_id"],
-                author["sympy_commits"], author["github_id"],
+                author["sympy_commits"], sympy_commit_id,
                 author["github_id"], author["github_id"],
                 author["institution"], author["institution_address_siam"],
                 ))

--- a/authors/list_text.py
+++ b/authors/list_text.py
@@ -2,18 +2,66 @@
 
 from __future__ import print_function
 
+from io import open
 from json import load
 
 author_list = load(open("authors.json"))
+author_list = list(filter(lambda x: x["sympy_commits"] > 0, author_list))
 
-print("List of authors:")
-print()
+print("Generating authors.md")
 
-for author in author_list:
-    print("Author:", author["name"])
-    print("Affiliation:", author["institution"])
-    print("Address:", author["institution_address"])
-    print("GitHub profile: https://github.com/%s" % author["github_id"])
-    print("Article commits: https://github.com/sympy/sympy-paper/commits?author=%s" % author["github_id"])
-    print("Article comments on issues and PRs: https://github.com/sympy/sympy-paper/search?q=%s&type=Issues" % author["github_id"])
-    print()
+with open("authors.md", "w", encoding='utf-8') as f:
+    f.write(u"""\
+# Article Authors
+
+All authors satisfy the following ICMJE [criteria](http://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html#two) for authorship:
+
+1. Substantial contributions to the conception or design of the work; or the
+   acquisition, analysis, or interpretation of data for the work; AND
+
+2. Drafting the work or revising it critically for important intellectual
+   content; AND
+
+3. Final approval of the version to be published; AND
+
+4. Agreement to be accountable for all aspects of the work in ensuring that
+   questions related to the accuracy or integrity of any part of the work are
+   appropriately investigated and resolved.
+
+
+The column `SymPy Commits` lists how many commits the authors contributed to
+SymPy (with a link to the actual commits), which shows how the requirement 1.
+is satisfied.
+
+The column `Article Contributions` lists all commits and comments to the
+article itself, which shows how the requirement 2. is satisfied.
+
+All authors approved the final version of the article, satisfying the
+requirement 3.
+
+Finally, all authors agreed to the requirement 4.
+
+""")
+    f.write(u"\n")
+    f.write(u"| Author | GitHub Profile | SymPy Commits | "
+            "Article Contributions | Affiliation |\n")
+    f.write(u"| :---   | :---           |     :---:     | "
+            ":---                  | :---        |\n")
+
+    for author in author_list:
+        f.write(u"| %s | [@%s](https://github.com/%s) | "
+            "[%d](https://github.com/sympy/sympy/commits?author=%s) | "
+            "[commits](https://github.com/sympy/sympy-paper/commits?author=%s),"
+                " [comments](https://github.com/sympy/sympy-paper/search"
+                "?q=%s&type=Issues) "
+            "| %s, %s |\n" % (
+                author["name"],
+                author["github_id"], author["github_id"],
+                author["sympy_commits"], author["github_id"],
+                author["github_id"], author["github_id"],
+                author["institution"], author["institution_address_siam"],
+                ))
+
+    f.write(u"\n")
+    f.write(u"Note: This file was automatically generated from "
+        "`authors.json` using `list_text.py`\n")

--- a/authors/list_text.py
+++ b/authors/list_text.py
@@ -61,7 +61,7 @@ Finally, all authors agreed to the requirement 4.
             "[%d](https://github.com/sympy/sympy/commits?author=%s) | "
             "[commits](https://github.com/sympy/sympy-paper/commits?author=%s),"
                 " [comments](https://github.com/sympy/sympy-paper/search"
-                "?q=%s&type=Issues) "
+                "?q=commenter:%s&type=Issues) "
             "| %s, %s |\n" % (
                 author["name"],
                 author["github_id"], author["github_id"],

--- a/authors/list_text.py
+++ b/authors/list_text.py
@@ -72,4 +72,4 @@ Finally, all authors agreed to the requirement 4.
 
     f.write(u"\n")
     f.write(u"Note: This file was automatically generated from "
-        "`authors.json` using `list_text.py`\n")
+        "`authors.json` using `list_text.py`.\n")


### PR DESCRIPTION
This is important and once the article gets accepted, we should put this table into the README, so that anyone can easily check that all authors satisfy the authorship criteria, as well as to see what each author actually did in the article.

I didn't commit the generated file for now, so that we don't have conflicts. Once all authors are in, I suggest we commit the generated file, so that it's easy to see on GitHub. See my comment below how it looks like.
