### PR TITLE
Introduce an optional author_order

### DIFF
--- a/authors/authors.json
+++ b/authors/authors.json
@@ -162,15 +162,6 @@
         "sympy_commits": 17
     },
     {
-        "email": "scopatz@cec.sc.edu",
-        "github_id": "scopatz",
-        "institution": "University of South Carolina",
-        "institution_address": "541 Main St., Columbia, SC, 29201",
-        "institution_address_siam": "Columbia, SC 29201",
-        "name": "Anthony Scopatz",
-        "sympy_commits": 15
-    },
-    {
         "email": "isuru.11@cse.mrt.ac.lk",
         "github_id": "isuruf",
         "institution": "University of Moratuwa",
@@ -197,5 +188,15 @@
         "name": "Robert Cimrman",
         "sympy_commit_email": "robert.cimrman@gmail.com",
         "sympy_commits": 1
+    },
+    {
+        "author_order": 0,
+        "email": "scopatz@cec.sc.edu",
+        "github_id": "scopatz",
+        "institution": "University of South Carolina",
+        "institution_address": "541 Main St., Columbia, SC, 29201",
+        "institution_address_siam": "Columbia, SC 29201",
+        "name": "Anthony Scopatz",
+        "sympy_commits": 15
     }
 ]

--- a/authors/prettify.py
+++ b/authors/prettify.py
@@ -6,7 +6,13 @@ from json import load, dumps
 from io import open
 
 author_list = load(open("authors.json"))
-author_list.sort(key=lambda x: x["sympy_commits"], reverse=True)
+for author in author_list:
+    if "author_order" not in author:
+        author["author_order"] = author["sympy_commits"]
+author_list.sort(key=lambda x: x["author_order"], reverse=True)
+for author in author_list:
+    if author["author_order"] == author["sympy_commits"]:
+        del author["author_order"]
 
 with open("authors.json", "w", encoding='utf-8') as f:
     data = dumps(author_list, ensure_ascii=False, sort_keys=True, indent=4,


### PR DESCRIPTION
If present, it will be used instead of sympy_commits to order authors. This
allows us to modify the order of authors. The `author_order` is only used for
ordering, it is not used for anything else (like listing the number of
patches).

Fixes @scopatz's request at https://github.com/sympy/sympy-paper/pull/160#issuecomment-221721955
