### PR TITLE
Compile with PeerJ template

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -77,3 +77,11 @@ citations and "URL citations".
 - [x] Something on printers
 
 - [x] Conclusion
+
+## PeerJ:
+
+  [ ] Add keywords
+
+  [ ] Switch to author-year citations
+
+  [ ] Merge or decide how to refer to supplement

--- a/authors/list_latex.py
+++ b/authors/list_latex.py
@@ -9,12 +9,9 @@ author_list = load(open("authors.json"))
 author_list = list(filter(lambda x: x["sympy_commits"] > 0, author_list))
 
 with open("../authors.tex", "w", encoding='utf-8') as f:
-    f.write(u"\\author{%\n")
     for n, author in enumerate(author_list):
-        f.write((u"%s%%\n" % author["name"]))
-        f.write(u"\\thanks{%s, %s (\\email{%s}).}%%\n" \
-                % (author["institution"], author["institution_address_siam"],
+        f.write((u"\\author[%d]{%s}%%\n" % (n+1, author["name"])))
+    for n, author in enumerate(author_list):
+        f.write(u"\\affil[%d]{%s, %s (\\email{%s}).}%%\n" \
+                % (n+1, author["institution"], author["institution_address_siam"],
                     author["email"]))
-        if n < len(author_list) - 1:
-            f.write(u"\\and\n")
-    f.write(u"}\n")

--- a/paper.bib
+++ b/paper.bib
@@ -1922,8 +1922,9 @@ ng {C}omputations in {C}ommutative {A}lgebra},
 
 @misc{Bronstein2005pmint,
     author        = {Manuel Bronstein},
-    title         = {{P}oor {M}an's {I}ntegrator},
+    title         = {pmint---{T}he {P}oor {M}an's {I}ntegrator},
     url           = {http://www-sop.inria.fr/cafe/Manuel.Bronstein/pmint},
+    year          = {2005},
     keywords      = {},
 }
 

--- a/paper.tex
+++ b/paper.tex
@@ -1,8 +1,14 @@
-% SIAM Article Template
-\documentclass[review]{siamart0216}
+%% Submissions for peer-review must enable line-numbering 
+%% using the lineno option in the \documentclass command.
+%%
+%% Preprints and camera-ready submissions do not need 
+%% line numbers, and should have this option removed.
+%%
+%% Please note that the line numbering option requires
+%% version 1.1 or newer of the wlpeerj.cls file.
 
-% Apply a fix to the SIAM Article Template
-\input{siamart0216_uppercase_fix}
+\documentclass[fleqn,10pt,lineno]{wlpeerj} % for journal submissions
+% \documentclass[fleqn,10pt]{wlpeerj} % for preprint submissions
 
 \usepackage{lmodern}
 \usepackage[T1]{fontenc}
@@ -45,12 +51,12 @@
 
 \usepackage{listings}
 
+\newcommand\email[1]{\href{mailto:#1}{#1}}
 \title{SymPy: Symbolic Computing in Python}
 
 \input{authors}
 
-\begin{document}
-\maketitle
+\keywords{Keyword1, Keyword2, Keyword3}
 
 \begin{abstract}
   SymPy is an open source computer algebra system written in pure Python. It
@@ -61,6 +67,12 @@
   architecture of SymPy, a description of its features, and a discussion of
   select domain specific submodules.
 \end{abstract}
+
+\begin{document}
+
+\flushbottom
+\maketitle
+\thispagestyle{empty}
 
 \section{Introduction}
 
@@ -114,9 +126,6 @@
 
 \input{acknowledgements}
 
-\section{References}
-
-\bibliographystyle{siamplain}
 \bibliography{paper}
 
 \end{document}

--- a/supplement.tex
+++ b/supplement.tex
@@ -1,8 +1,16 @@
-% SIAM Article Template
-\documentclass[supplement]{siamart0216}
+%% Submissions for peer-review must enable line-numbering 
+%% using the lineno option in the \documentclass command.
+%%
+%% Preprints and camera-ready submissions do not need 
+%% line numbers, and should have this option removed.
+%%
+%% Please note that the line numbering option requires
+%% version 1.1 or newer of the wlpeerj.cls file.
 
-% Apply a fix to the SIAM Article Template
-\input{siamart0216_uppercase_fix}
+\documentclass[fleqn,10pt,lineno]{wlpeerj} % for journal submissions
+% \documentclass[fleqn,10pt]{wlpeerj} % for preprint submissions
+
+%\usepackage[numbers]{natbib}
 
 \usepackage{lmodern}
 \usepackage[T1]{fontenc}
@@ -45,12 +53,16 @@
 
 \usepackage{listings}
 
-\title{SymPy: Symbolic Computing in Python}
-
-\input{authors}
 
 \begin{document}
-\maketitle
+
+\flushbottom
+\thispagestyle{empty}%
+\vskip-36pt%
+{\raggedright\sffamily\bfseries\fontsize{20}{25}\selectfont SymPy: Symbolic Computing in Python\par}%
+\vskip10pt
+{\raggedright\sffamily\fontsize{12}{16}\selectfont  Supplementary material\par}
+\vskip25pt%
 
 As in the paper, all examples in the supplement assume that the following
 has been run:
@@ -116,7 +128,6 @@ has been run:
 
 \section{References}
 
-\bibliographystyle{siamplain}
 \bibliography{paper}
 
 \end{document}

--- a/wlpeerj.cls
+++ b/wlpeerj.cls
@@ -41,7 +41,8 @@
                 labelsep=period,%
                 justification=raggedright]{caption}
                 
-\RequirePackage{natbib}
+% custom modification - use numbered citations
+\RequirePackage[numbers]{natbib}
 \bibliographystyle{apalike}
 
 %


### PR DESCRIPTION
These commits contain minimal changes to make the article compile within the peerj template from [Overleaf](https://www.overleaf.com/latex/templates/latex-template-for-peerj-journal-and-pre-print-submissions/ptdwfrqxqzbn). There are still some issues:
- author-year citations are disabled as that would probably require some changes to the text
- the template is not suited for typesetting supplementary information. Formatting and referring to the supplement needs to be resolved
- keywords are missing

and probably others
