### PR TITLE
Fix mistakes in the Gruntz algorithm example

### DIFF
--- a/gruntz.tex
+++ b/gruntz.tex
@@ -33,9 +33,8 @@ The Gruntz algorithm is now illustrated with the following example:
     \label{gruntz_example_fn}
 f(x) = e^{x+2e^{-x}} - e^x + {1\over x} \,.
 \end{equation}
-The goal is to calculate $\lim\limits_{x\to\infty} f(x)$. First, the set of
-most rapidly varying subexpressions is determined---the so-called \textit{mrv
-  set}. For~\eqref{gruntz_example_fn}, the mrv set
+First, the set of most rapidly varying subexpressions is determined ---
+the so-called \textit{mrv set}. For~\eqref{gruntz_example_fn}, the mrv set
 $\{e^x, e^{-x}, e^{x+2e^{-x}}\}$ is obtained. These are all subexpressions of%
 ~\eqref{gruntz_example_fn} and they all belong to the same comparability
 class. This calculation can be done using SymPy as follows:
@@ -48,14 +47,40 @@ class. This calculation can be done using SymPy as follows:
 dict_keys([exp(x + 2*exp(-x)), exp(x), exp(-x)])
 \end{verbatim}
 
-Next, an arbitrary item $\omega$ is taken from mrv that converges to zero for
-$x\to\infty$. The item $\omega=e^{-x}$ is obtained. If such a term is not
+Next, an arbitrary item $\omega$ is taken from mrv set that converges to zero for
+$x\to\infty$ and doesn't have subexpressions in the given mrv set.  In our case,
+only item $\omega=e^{-x}$ can be accepted.  If such a term is not
 present in the mrv set (i.e., all terms converge to infinity instead of zero),
 the relation $f(x)\sim {1\over f(x)}$ can be used.
 
-The next step is to rewrite the mrv set in terms of $\omega$: $\{{1\over\omega},
-\omega, {1\over\omega}e^{2\omega}\}$. Then the original subexpressions are
-substituted back into $f(x)$ and expanded with respect to~$\omega$:
+The next step is to rewrite the mrv set in terms of $\omega=g(x)$.  Every element
+$f(x)$ of the mrv set is rewritten as $A \omega^c$, where
+\begin{equation}
+\label{gruntz_rewrite}
+c = \lim\limits_{x\to\infty} \frac{\log{f(x)}}{\log{g(x)}},
+\qquad
+A = e^{\log f - c \log g}
+\end{equation}
+Note that this step include calculation of more simple limits, for instance
+\begin{equation}
+	\lim\limits_{x\to\infty} \frac{\log{e^{x + 2 e^{-x}}}}{\log e^{-x}}=
+	\lim\limits_{x\to\infty} \frac{x + 2 e^{-x}}{-x} = -1
+\end{equation}
+In our example we obtain the rewritten mrv set: $\{{1\over\omega},
+\omega, {1\over\omega}e^{2\omega}\}$. This can be done in the SymPy with
+\begin{verbatim}
+>>> from sympy.series.gruntz import mrv, rewrite
+>>> m = mrv(exp(x+2*exp(-x))-exp(x) + 1/x, x)
+>>> w = Symbol('w')
+>>> rewrite(m[1], m[0], x, w)[0]
+     2*w
+1   e      1
+- + ---- - -
+x    w     w
+\end{verbatim}
+Then the rewritten subexpressions are
+substituted back into $f(x)$ in~(\ref{gruntz_example_fn})
+and the result is expanded with respect to~$\omega$:
 \begin{equation}
     \label{gruntz_example_fn2}
 f(x) = {1\over x}-{1\over\omega}+{1\over\omega}e^{2\omega}
@@ -70,7 +95,7 @@ f(x) = {1\over x}-{1\over\omega}+{1\over\omega}e^{2\omega}
     \to 2 + {1\over x}
 \end{equation}
 
-Since the result ($2+{1\over x}$) still depends on $x$, the above procedure is
+In our example the result ($2+{1\over x}$) still depends on $x$, so the above procedure is
 repeated until just a value independent of $x$ is obtained. This is the final
 limit. In the above case the limit is $2$, as can be
 verified by SymPy:
@@ -91,6 +116,7 @@ f(x) = \underbrace{O\left({1\over \omega^3}\right)}_\infty
 \end{equation}
 The positive powers of $\omega$ are zero. If there are any negative powers of
 $\omega$, then the result of the limit is infinity, otherwise the limit is
-equal to $\lim\limits_{x\to\infty} C_0(x)$. The expression $C_0(x)$ is simpler
-than $f(x)$ and so the algorithm always converges. A proof of this and further
+equal to $\lim\limits_{x\to\infty} C_0(x)$. The expression $C_0(x)$ is always
+simpler than original $f(x)$, same is true for limits, arising in the
+rewrite stage~(\ref{gruntz_rewrite}), so the algorithm converges. A proof of this and further
 details on the algorithm are given in Gruntz's PhD thesis~\cite{Gruntz1996limits}.

--- a/gruntz.tex
+++ b/gruntz.tex
@@ -48,10 +48,10 @@ dict_keys([exp(x + 2*exp(-x)), exp(x), exp(-x)])
 \end{verbatim}
 
 Next, an arbitrary item $\omega$ is taken from mrv set that converges to zero for
-$x\to\infty$ and doesn't have subexpressions in the given mrv set.  In our case,
-only item $\omega=e^{-x}$ can be accepted.  If such a term is not
+$x\to\infty$ and doesn't have subexpressions in the given mrv set.  If such a term is not
 present in the mrv set (i.e., all terms converge to infinity instead of zero),
-the relation $f(x)\sim {1\over f(x)}$ can be used.
+the relation $f(x)\sim {1\over f(x)}$ can be used.  In the
+considered case, only item $\omega=e^{-x}$ can be accepted.
 
 The next step is to rewrite the mrv set in terms of $\omega=g(x)$.  Every element
 $f(x)$ of the mrv set is rewritten as $A \omega^c$, where
@@ -61,22 +61,19 @@ c = \lim\limits_{x\to\infty} \frac{\log{f(x)}}{\log{g(x)}},
 \qquad
 A = e^{\log f - c \log g}
 \end{equation}
-Note that this step include calculation of more simple limits, for instance
+Note that this step includes calculation of more simple limits, for instance
 \begin{equation}
 	\lim\limits_{x\to\infty} \frac{\log{e^{x + 2 e^{-x}}}}{\log e^{-x}}=
 	\lim\limits_{x\to\infty} \frac{x + 2 e^{-x}}{-x} = -1
 \end{equation}
-In our example we obtain the rewritten mrv set: $\{{1\over\omega},
-\omega, {1\over\omega}e^{2\omega}\}$. This can be done in the SymPy with
+In this example we obtain the rewritten mrv set: $\{{1\over\omega},
+\omega, {1\over\omega}e^{2\omega}\}$. This can be done in SymPy with
 \begin{verbatim}
 >>> from sympy.series.gruntz import mrv, rewrite
 >>> m = mrv(exp(x+2*exp(-x))-exp(x) + 1/x, x)
 >>> w = Symbol('w')
 >>> rewrite(m[1], m[0], x, w)[0]
-     2*w
-1   e      1
-- + ---- - -
-x    w     w
+1/x + exp(2*w)/w - 1/w
 \end{verbatim}
 Then the rewritten subexpressions are
 substituted back into $f(x)$ in~(\ref{gruntz_example_fn})
@@ -95,7 +92,7 @@ f(x) = {1\over x}-{1\over\omega}+{1\over\omega}e^{2\omega}
     \to 2 + {1\over x}
 \end{equation}
 
-In our example the result ($2+{1\over x}$) still depends on $x$, so the above procedure is
+In this example the result ($2+{1\over x}$) still depends on $x$, so the above procedure is
 repeated until just a value independent of $x$ is obtained. This is the final
 limit. In the above case the limit is $2$, as can be
 verified by SymPy:


### PR DESCRIPTION
1. how to choose subexpression omega (this part was: wrong)
2. the rewrite stage (was: non-exsistent), I hope
   now it's clear how to rewrite elements of the mrv set,
   and this is not a magic step for our readers (or worse,
   for "authors" of the SymPy) anymore.
3. mention the rewrite stage in comment about the
   algorithm termination.
4. some minor fixes, i.e. "The goal is to calculate" was
   dropped, the Gruntz algorithm IS about calculation limits
   at the infinity.
