### PR TITLE
Final fixes

### DIFF
--- a/authors/authors.json
+++ b/authors/authors.json
@@ -82,7 +82,7 @@
             "Department of Applied Mathematics, Delhi Technological University, New Delhi, India"
         ],
         "institution_address_siam": "Shahbad Daulatpur, Bawana Road, New Delhi 110042, India",
-        "name": "AMiT Kumar",
+        "name": "Amit Kumar",
         "sympy_commits": 263
     },
     {

--- a/domain_specific.tex
+++ b/domain_specific.tex
@@ -57,7 +57,7 @@ algebraic equations that govern the motion of the system, i.e., the equations
 of motion. These equations of motion abide by Newton's laws of motion and can
 handle arbitrary kinematic constraints or complex loads. The submodule
 offers two automated methods for formulating the equations of motion based on
-Lagrangian Dynamics~\cite{Lagrange1811} and Kane's Method~\cite{Kane1985}.
+Lagrangian Dynamics~\cite{Lagrange1811} and Kane's Method~\cite{kane1985dynamics}.
 Lastly, there are automated linearization routines for constrained dynamical
 systems~\cite{Peterson2014}.
 
@@ -66,7 +66,7 @@ systems~\cite{Peterson2014}.
 
 The \verb|sympy.physics.quantum| submodule has extensive capabilities to
 solve problems in quantum mechanics, using Python objects to represent the
-different mathematical objects relevant in quantum theory~\cite{Sakurai2010}:
+different mathematical objects relevant in quantum theory~\cite{sakurai2011modern}:
 states (bras and kets), operators (unitary, Hermitian, etc.), and basis sets, as
 well as operations on these objects such as representations, tensor products,
 inner products, outer products, commutators, and anticommutators. The base
@@ -103,9 +103,9 @@ oscillator states and raising/lowering operators, infinite square well states,
 and 3D position and momentum operators and states.
 
 \item Second quantized formalism of non-relativistic many-body quantum
-mechanics~\cite{FetterWalecka2003}.
+mechanics~\cite{fetter2003quantum}.
 
-\item Quantum angular momentum~\cite{Zare1991}. Spin operators and their
+\item Quantum angular momentum~\cite{zare1988angular}. Spin operators and their
 eigenstates can be represented in any basis and for any quantum numbers.
 A rotation operator representing the Wigner D-matrix, which may be defined
 symbolically or numerically, is also implemented to rotate spin eigenstates.
@@ -113,7 +113,7 @@ Functionality for coupling and uncoupling of arbitrary spin eigenstates is
 provided, including symbolic representations of Clebsch-Gordon coefficients and
 Wigner symbols.
 
-\item Quantum information and computing~\cite{Nielsen2011}. Multidimensional
+\item Quantum information and computing~\cite{nielsen2010quantum}. Multidimensional
 qubit states, and a full set of one- and two-qubit gates are provided and can
 be represented symbolically or as matrices/vectors. With these building blocks,
 it is possible to implement a number of basic quantum algorithms including the

--- a/features.tex
+++ b/features.tex
@@ -51,7 +51,7 @@ linear-feedback shift registers, and Elgamal encryption.\\
 
 Differential Geometry (\texttt{sympy.diffgeom}) & Representations of manifolds, metrics, tensor
 products, and coordinate systems in Riemannian and pseudo-Riemannian
-geometries~\cite{FunctionalDifferentialGeometry}.\\
+geometries~\cite{sussman2013functional}.\\
 % TODO: Someone verify that this is a good summary of the diffgeom module
 
 Geometry (\texttt{sympy.geometry}) & Representations of 2D geometrical entities, such as lines and
@@ -84,7 +84,7 @@ plotting, and 2D implicit function plotting are supported.\\
 
 Polynomials (\texttt{sympy.polys}) & Polynomial algebras over various coefficient domains.
 Functionality ranges from simple operations (e.g., polynomial division) to
-advanced computations (e.g., Gr\"obner bases~\cite{adams1994introduction} and multivariate
+advanced computations (e.g., Gr\"obner bases~\cite{Adams1994intro} and multivariate
 factorization over algebraic number domains).\\
 
 Printing (\texttt{sympy.printing}) & Functions for printing SymPy expressions in the terminal with ASCII
@@ -125,7 +125,7 @@ spherical harmonic functions.\\
 
 Statistics (\texttt{sympy.stats}) & Support for a random variable type as well as the ability to
 declare this variable from prebuilt distribution functions such as
-Normal, Exponential, Coin, Die, and other custom distributions~\cite{StatsMRocklin}.\\
+Normal, Exponential, Coin, Die, and other custom distributions~\cite{rocklin2012symbolic}.\\
 
 Tensors (\texttt{sympy.tensor}) & Symbolic manipulation of indexed objects.\\
 

--- a/gamma.tex
+++ b/gamma.tex
@@ -1,5 +1,5 @@
 \href{http://sympygamma.com}{SymPy Gamma} is a simple web application that
-runs on the Google App Engine~\cite{ciurana2009google}. It executes and
+runs on the Google App Engine~\cite{ciurana2009developing}. It executes and
 displays the results of SymPy expressions as well as additional related
 computations, in a fashion similar to that of Wolfram\textbar{}Alpha. For
 instance, entering an integer will display its prime factors, digits in the

--- a/introduction.tex
+++ b/introduction.tex
@@ -86,6 +86,6 @@ executed:\footnote{\label{note:prompt} The three greater-than signs denote the u
 
 All the examples in this paper can be tested on
 \href{http://live.sympy.org}{SymPy Live}, an online Python shell that uses the
-Google App Engine~\cite{ciurana2009google} to execute SymPy code. SymPy Live
+Google App Engine~\cite{ciurana2009developing} to execute SymPy code. SymPy Live
 is also integrated into the SymPy documentation at
 \href{http://docs.sympy.org}{http://docs.sympy.org}.

--- a/numerics.tex
+++ b/numerics.tex
@@ -128,7 +128,7 @@ Bessel functions, orthogonal polynomials, elliptic functions and integrals,
 zeta and polylogarithm functions,
 the generalized hypergeometric function, and the Meijer G-function.
 The Meijer G-function instance
-$G_{1, 3}^{3, 0}\left(0 ; \tfrac{1}{2}, -1, - \tfrac{3}{2} | x \right)$
+$G_{1, 3}^{3, 0}\left(0 ; \tfrac{1}{2}, -1, - \tfrac{3}{2} \middle | x \right)$
 is a good test case~\cite{Toth2007}; past versions of both Maple and
 Mathematica produced incorrect numerical values for large $x > 0$.
 Here, mpmath automatically removes an internal singularity

--- a/paper.bib
+++ b/paper.bib
@@ -3850,7 +3850,7 @@ Year         = {2016},
 }
 
 @manual{rose1999xy,
-  title={XY-pic User’s Guide},
+  title={XY-pic User's Guide},
   author={Rose, Kristoffer H},
   year={1999},
   publisher={Dispon{\i}vel em: http://tug. org/applications/Xy-pic/soft/xyguide. ps. gz},

--- a/paper.bib
+++ b/paper.bib
@@ -2543,6 +2543,8 @@ ng {C}omputations in {C}ommutative {A}lgebra},
     author        = {William Wells Adams and Philippe Loustaunau},
     title         = {{A}n {I}ntroduction to {G}r\"{o}bner {B}ases},
     pages         = {289+},
+    series        = {Graduate Studies in Mathematics},
+    volume        = {3},
     month         = {July},
     year          = {1994},
     publisher     = pub:ams,
@@ -3141,6 +3143,18 @@ ng {C}omputations in {C}ommutative {A}lgebra},
   publisher="McGraw Hill"
 }
 
+@book{kane1985dynamics,
+  title={Dynamics, Theory and Applications},
+  author={Kane, T.R. and Levinson, D.A.},
+  isbn={9780070378469},
+  lccn={84021802},
+  series={McGraw-Hill series in mechanical engineering},
+  url={https://books.google.com/books?id=g99oQgAACAAJ},
+  year={1985},
+  publisher={McGraw-Hill},
+  address=adr:new_york
+}
+
 @misc{Wolfram2016,
   title = {The Software Engineering of the Wolfram System},
   url = {https://reference.wolfram.com/language/tutorial/TheSoftwareEngineeringOfTheWolframSystem.html},
@@ -3169,7 +3183,8 @@ ng {C}omputations in {C}ommutative {A}lgebra},
   title={Graph Theory, 1736-1936},
   author={Biggs, Norman and Lloyd, E Keith and Wilson, Robin J},
   year={1976},
-  publisher={Oxford University Press}
+  publisher={Oxford University Press},
+  address=adr:oxford
 }
 
 @article{Sofroniou2005precise,
@@ -3333,9 +3348,13 @@ ng {C}omputations in {C}ommutative {A}lgebra},
 
 @article{Peeters2007cadabra,
   title={Cadabra: a field-theory motivated symbolic computer algebra system},
-  author={Kasper Peeters},
+  author={Peeters, Kasper},
   journal={Computer Physics Communications},
+  volume={176},
+  number={8},
+  pages={550--558},
   year={2007},
+  publisher={Elsevier}
 }
 
 @misc{xAct,
@@ -3384,6 +3403,18 @@ ng {C}omputations in {C}ommutative {A}lgebra},
   edition =      {Seventh Edition},
   doi =          {10.1016/B978-1-85617-633-0.00019-8},
   isbn =         {978-1-85617-633-0},
+}
+
+@book{zienkiewicz2013finite,
+  title={The Finite Element Method: Its Basis and Fundamentals},
+  author={Zienkiewicz, O.C. and Taylor, R.L. and Zhu, J.Z.},
+  isbn={9780080951355},
+  lccn={2014397935},
+  edition={seventh},
+  url={https://books.google.com/books?id=7UL5Ls9hOF8C},
+  year={2013},
+  publisher={Elsevier Science},
+  address={Waltham, MA, USA}
 }
 
 @Book{Fung1993contmech,
@@ -3445,11 +3476,34 @@ publisher = {Addison-Wesley},
 year = 2010
 }
 
+@book{sakurai2011modern,
+  title={Modern Quantum Mechanics},
+  author={Sakurai, J.J. and Napolitano, J.},
+  isbn={9780805382914},
+  lccn={2010022349},
+  url={https://books.google.com/books?id=N4I-AQAACAAJ},
+  year={2011},
+  publisher={Addison-Wesley},
+  address=adr:reading
+}
+
 @book{Zare1991,
 title     = {Angular Momentum: Understanding Spatial Aspects in Chemistry and Physics},
 author    = {Zare, R.N.},
 publisher = {Wiley},
 year = 1991
+}
+
+
+@book{zare1988angular,
+  title={Angular momentum: understanding spatial aspects in chemistry and physics},
+  author={Zare, R.N.},
+  isbn={9780471858928},
+  lccn={87016204},
+  series={George Fisher Baker non-resident lectureship in chemistry at Cornell University},
+  url={https://books.google.com/books?id=kDQ31MBZxioC},
+  year={1988},
+  publisher={Wiley}
 }
 
 @book{Nielsen2011,
@@ -3459,6 +3513,17 @@ publisher = {Cambridge University Press},
 year = 2011
 }
 
+@book{nielsen2010quantum,
+  title={Quantum Computation and Quantum Information: 10th Anniversary Edition},
+  author={Nielsen, M.A. and Chuang, I.L.},
+  isbn={9781139495486},
+  url={https://books.google.com/books?id=-s4DEy7o-a0C},
+  year={2010},
+  publisher={Cambridge University Press},
+  address=adr:new_york
+
+}
+
 @book{FetterWalecka2003,
 title	= {Quantum Theory of Many-Particle Systems},
 author	= {Fetter, A.L. and Walecka, J.D.},
@@ -3466,11 +3531,34 @@ publisher = {Dover Publications},
 year	= 2003
 }
 
+@book{fetter2003quantum,
+  title={Quantum Theory of Many-particle Systems},
+  author={Fetter, A.L. and Walecka, J.D.},
+  isbn={9780486428277},
+  lccn={2003043536},
+  series={Dover Books on Physics},
+  url={https://books.google.com/books?id=0wekf1s83b0C},
+  year={2003},
+  publisher={Dover Publications},
+  address={Mineola, New York}
+}
+
 @book{FunctionalDifferentialGeometry,
 title = {Functional Differential Geometry},
 author = {Gerald Jay Sussman and Jack Wisdom},
 publisher = {Massachusetts Institute of Technology Press},
 year = {2013},
+}
+
+@book{sussman2013functional,
+  title={Functional Differential Geometry},
+  author={Sussman, G.J. and Wisdom, J. and Farr, W.},
+  isbn={9780262019347},
+  lccn={2012042107},
+  url={https://books.google.com/books?id=BSodAAAAQBAJ},
+  year={2013},
+  publisher={MIT Press},
+  address=adr:cambridge
 }
 
 @article{StatsMRocklin,
@@ -3483,6 +3571,16 @@ month = {May-June},
 year = {2012}
 }
 
+@article{rocklin2012symbolic,
+  title={Symbolic Statistics with SymPy},
+  author={Rocklin, Matthew and Terrel, Andy R},
+  journal={Computing in Science \& Engineering},
+  volume={14},
+  number={3},
+  pages={88--93},
+  year={2012},
+  publisher={AIP Publishing}
+}
 @misc{ct4commutativity,
   url={https://github.com/scolobb/sympy/tree/ct4-commutativity}
 }
@@ -3507,18 +3605,25 @@ year = {2012}
 }
 
 @book{lutz2013learning,
-  title={Learning Python},
-  author={Lutz, Mark},
+  title={Learning Python: Powerful Object-Oriented Programming},
+  author={Lutz, M.},
+  isbn={9781449355692},
+  series={Safari Books Online},
+  url={https://books.google.com/books?id=4pgQfXQvekcC},
   year={2013},
-  publisher={O'Reilly Media, Inc.}
+  publisher={O'Reilly Media},
+  address={Sebastopol, CA, USA}
 }
 
 @book{rosen2005open,
-  title={Open source licensing},
-  author={Rosen, Lawrence},
-  volume={692},
+  title={Open Source Licensing: Software Freedom and Intellectual Property Law},
+  author={Rosen, L.E.},
+  isbn={9780131487871},
+  lccn={20050558},
+  url={https://books.google.com/books?id=HGokAQAAIAAJ},
   year={2005},
-  publisher={Prentice Hall}
+  publisher={Prentice Hall PTR},
+  address={Upper Saddle River, NJ, USA}
 }
 
 @Book{Shaw1996,
@@ -3534,15 +3639,19 @@ Provides the intellectual building blocks for designing new systems in principle
 Shows how formal notations and models can be used to characterize and reason about a system design,
 Presents concrete examples of actual system architectures that can serve as models for new designs
 },
-      NOTE = {Prentice Hall Ordering Information},
-      KEYWORDS = {Software Architecture}
+      KEYWORDS = {Software Architecture},
+      ADDRESS = {Pittsburgh, PA, USA}
 }
 
-@article{lang1966introduction,
+@book{lang1966introduction,
   title={Introduction to transcendental numbers},
-  author={Lang, Serge},
-  journal={Reading, Mass},
-  year={1966}
+  author={Lang, S.},
+  lccn={66028459},
+  series={Addison-Wesley series in mathematics},
+  url={https://books.google.com/books?id=vLo-AAAAIAAJ},
+  year={1966},
+  publisher={Addison-Wesley Pub. Co.},
+  address=adr:reading
 }
 
 @article{gosper1978decision,
@@ -3565,10 +3674,14 @@ Presents concrete examples of actual system architectures that can serve as mode
 
 @book{tai1997generalized,
   title={Generalized vector and dyadic analysis: applied mathematics in field theory},
-  author={Tai, Chen-To},
-  volume={9},
+  author={Tai, C.},
+  isbn={9780780334137},
+  lccn={96029863},
+  series={IEEE/OUP series on electromagnetic wave theory},
+  url={https://books.google.com/books?id=NftQAAAAMAAJ},
   year={1997},
-  publisher={Wiley-IEEE Press}
+  publisher={Wiley-IEEE Press},
+  address=adr:new_york
 }
 
 @incollection{dsl-little-languages,
@@ -3725,11 +3838,24 @@ Year         = {2016},
   publisher={Springer}
 }
 
-@article{rose1999xy,
+@book{ciurana2009developing,
+  title={Developing with Google App Engine},
+  author={Ciurana, E.},
+  isbn={9781430218326},
+  series={FirstPress (En ligne)},
+  url={https://books.google.com/books?id=jUXh-Hl36oQC},
+  year={2009},
+  publisher={Apress},
+  address=adr:berkeley
+}
+
+@manual{rose1999xy,
   title={XY-pic User’s Guide},
   author={Rose, Kristoffer H},
   year={1999},
-  publisher={Dispon{\i}vel em: http://tug. org/applications/Xy-pic/soft/xyguide. ps. gz}
+  publisher={Dispon{\i}vel em: http://tug. org/applications/Xy-pic/soft/xyguide. ps. gz},
+  url={http://ctan.org/tex-archive/macros/generic/diagrams/xypic/doc/xyguide.pdf},
+  note={\url{http://ctan.org/tex-archive/macros/generic/diagrams/xypic/doc/xyguide.pdf}}
 }
 
 @phdthesis{rocklin2013mathematically,

--- a/paper.tex
+++ b/paper.tex
@@ -7,7 +7,7 @@
 %% Please note that the line numbering option requires
 %% version 1.1 or newer of the wlpeerj.cls file.
 
-\documentclass[fleqn,10pt,lineno,numbers]{wlpeerj} % for journal submissions
+\documentclass[fleqn,10pt,numbers]{wlpeerj} % for journal submissions
 % \documentclass[fleqn,10pt]{wlpeerj} % for preprint submissions
 
 \usepackage{lmodern}

--- a/projects_that_depend_on_sympy.tex
+++ b/projects_that_depend_on_sympy.tex
@@ -51,7 +51,7 @@ Table~\ref{projects-table}.
 \href{http://sfepy.org/}{\textbf{SfePy}} &
   A Python package for solving partial
   differential equations (PDEs) in 1D, 2D, and 3D by the finite element (FE)
-  method~\cite{Zienkiewicz2013FEM,cimrman2014sfepy}. \\
+  method~\cite{Zienkiewicz2013finite,cimrman2014sfepy}. \\
 
 \href{http://quameon.sourceforge.net/}{\textbf{Quameon}} & Quantum
   Monte Carlo in Python~\cite{quameon}. \\

--- a/stats.tex
+++ b/stats.tex
@@ -54,4 +54,4 @@ sqrt(2)*sqrt(kT)/sqrt(m)
 \end{verbatim}
 
 More information on the \texttt{sympy.stats} submodule can be found in
-\cite{StatsMRocklin}.
+\cite{rocklin2012symbolic}.

--- a/supplement.tex
+++ b/supplement.tex
@@ -7,7 +7,7 @@
 %% Please note that the line numbering option requires
 %% version 1.1 or newer of the wlpeerj.cls file.
 
-\documentclass[fleqn,10pt,lineno,numbers]{wlpeerj} % for journal submissions
+\documentclass[fleqn,10pt,numbers]{wlpeerj} % for journal submissions
 % \documentclass[fleqn,10pt]{wlpeerj} % for preprint submissions
 
 %\usepackage[numbers]{natbib}

--- a/supplement.tex
+++ b/supplement.tex
@@ -10,6 +10,9 @@
 \documentclass[fleqn,10pt,numbers]{wlpeerj} % for journal submissions
 % \documentclass[fleqn,10pt]{wlpeerj} % for preprint submissions
 
+\renewcommand\thesection{S\arabic{section}}
+\renewcommand\thesubsection{\thesection.\arabic{subsection}}
+
 %\usepackage[numbers]{natbib}
 
 \usepackage{lmodern}


### PR DESCRIPTION
Some final fixes, related to https://github.com/sympy/sympy-paper/issues/220.

As far as I know, we will not be resubmitting the paper itself, only pointing out changes in the annotations on the proof. So changes to the paper here are only for posterity, so that the paper here matches the final published version (at least in content). If someone wants, they can also bring in other changes from the proof (mainly, I noticed they changed the spelling section references in the text, and abbreviated US state names in the affiliations). 

We way wish to resubmit the supplement, as it has removed line numbers, and section numbers starting with S (the PeerJ staff have changed the references in the paper to use the "Section S1" format in their proof).