### PR TITLE
Correct link to galgebra

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -3785,7 +3785,7 @@ Year         = {2016},
   Key          = {galgebra},
   Author       = {Alan Bromborsky},
   Title        = {geometric algebra/calculus modules for SymPy},
-  note         = {\url{https://github.com/brombo/galgebra}},
+  note         = {\url{https://github.com/pygae/galgebra}},
   Year         = {2016},
 }
 

--- a/projects_that_depend_on_sympy.tex
+++ b/projects_that_depend_on_sympy.tex
@@ -42,7 +42,7 @@ Table~\ref{projects-table}.
 \href{http://www.pydy.org/}{\textbf{PyDy}} & Multibody Dynamics with
   Python~\cite{gede2013constrained}. \\
 
-\href{https://github.com/brombo/galgebra}{\textbf{galgebra}} &
+\href{https://github.com/pygae/galgebra}{\textbf{galgebra}} &
   A Python package for geometric algebra (previously \texttt{sympy.galgebra})~\cite{galgebra}. \\
 
 \href{http://yt-project.org/}{\textbf{yt}} & A Python package for


### PR DESCRIPTION
The link here is dead.

xref https://github.com/pygae/galgebra/issues/28

I have no idea whether it makes sense to accept corrections here, but I thought I may as well file the PR.